### PR TITLE
feat: Implement new project status workflow

### DIFF
--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -59,15 +59,14 @@ class Project extends Model
     {
         switch ($this->status) {
             case 'pending_research_cell':
-            case 'pending_admin_review':
+            case 'pending_admin':
+            case 'pending_supervisor':
                 return 'bg-yellow-50 text-yellow-600 dark:bg-yellow-500/15 dark:text-yellow-500';
-            case 'assigned_to_supervisor':
-            case 'in_progress':
-                return 'bg-blue-50 text-blue-600 dark:bg-blue-500/15 dark:text-blue-500';
             case 'completed':
                 return 'bg-green-50 text-green-600 dark:bg-green-500/15 dark:text-green-500';
-            case 'rejected_by_research_cell':
-            case 'cancelled':
+            case 'rejected_research_cell':
+            case 'rejected_admin':
+            case 'rejected_supervisor':
                 return 'bg-red-50 text-red-600 dark:bg-red-500/15 dark:text-red-500';
             default:
                 return 'bg-gray-50 text-gray-600 dark:bg-gray-500/15 dark:text-gray-400';

--- a/database/migrations/2025_08_17_043600_add_notes_to_projects_table.php
+++ b/database/migrations/2025_08_17_043600_add_notes_to_projects_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->text('notes')->nullable()->after('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->dropColumn('notes');
+        });
+    }
+};

--- a/database/migrations/2025_08_17_043630_update_status_enum_in_projects_table.php
+++ b/database/migrations/2025_08_17_043630_update_status_enum_in_projects_table.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // To prevent data loss, we'll first update the existing records to use the new status values.
+        DB::table('projects')->where('status', 'rejected_by_research_cell')->update(['status' => 'rejected_research_cell']);
+        DB::table('projects')->where('status', 'rejected_by_admin')->update(['status' => 'rejected_admin']);
+        DB::table('projects')->where('status', 'rejected_by_supervisor')->update(['status' => 'rejected_supervisor']);
+
+        // Then, we alter the table to use the new enum values.
+        Schema::table('projects', function (Blueprint $table) {
+            $table->enum('status', [
+                'pending_research_cell',
+                'rejected_research_cell',
+                'pending_admin',
+                'rejected_admin',
+                'pending_supervisor',
+                'rejected_supervisor',
+                'completed'
+            ])->default('pending_research_cell')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // To prevent data loss, we'll first update the existing records to use the old status values.
+        DB::table('projects')->where('status', 'rejected_research_cell')->update(['status' => 'rejected_by_research_cell']);
+        DB::table('projects')->where('status', 'rejected_admin')->update(['status' => 'rejected_by_admin']);
+        DB::table('projects')->where('status', 'rejected_supervisor')->update(['status' => 'rejected_by_supervisor']);
+
+        // Then, we alter the table to use the old enum values.
+        Schema::table('projects', function (Blueprint $table) {
+            $table->enum('status', [
+                'pending_research_cell',
+                'rejected_by_research_cell',
+                'pending_admin',
+                'rejected_by_admin',
+                'pending_supervisor',
+                'rejected_by_supervisor',
+                'completed'
+            ])->default('pending_research_cell')->change();
+        });
+    }
+};

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -71,6 +71,12 @@
                 <p class="text-gray-900">{{ $project->creator->name ?? 'N/A' }} ({{ $project->creator->email ?? 'N/A'
                     }})</p>
             </div>
+            @if(in_array($project->status, ['rejected_research_cell', 'rejected_admin', 'rejected_supervisor']))
+            <div class="md:col-span-2">
+                <p class="text-gray-700 text-sm font-semibold mb-1">Rejection Notes:</p>
+                <p class="text-red-600 leading-relaxed">{{ $project->notes }}</p>
+            </div>
+            @endif
         </div>
     </div>
 
@@ -120,11 +126,35 @@
 
     {{-- Action Buttons --}}
     <div class="flex justify-end gap-3 mt-8">
+        @php $user = auth()->user(); @endphp
+
+        @if(
+            ($user->role == 'research_cell' && $project->status == 'pending_research_cell') ||
+            ($user->role == 'admin' && $project->status == 'pending_admin') ||
+            ($user->role == 'supervisor' && $project->status == 'pending_supervisor')
+        )
+            <form action="{{ route('projects.approve', $project) }}" method="POST">
+                @csrf
+                <button type="submit" class="px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600 transition duration-200">
+                    Approve
+                </button>
+            </form>
+
+            <form action="{{ route('projects.reject', $project) }}" method="POST">
+                @csrf
+                <div class="flex items-center gap-2">
+                    <textarea name="notes" rows="1" class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" placeholder="Reason for rejection"></textarea>
+                    <button type="submit" class="px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600 transition duration-200">
+                        Reject
+                    </button>
+                </div>
+            </form>
+        @endif
+
         <a href="{{ route('projects.index') }}"
             class="px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 transition duration-200">
             Back to Project List
         </a>
-
     </div>
 </div>
 


### PR DESCRIPTION
This commit introduces a new project status workflow to simplify the project management process.

The following changes are included:
- The project status list is simplified and the names are shortened (e.g., `rejected_by_research_cell` is now `rejected_research_cell`).
- A `notes` column is added to the `projects` table to store rejection reasons.
- The project details page (`show.blade.php`) is updated to include "Approve" and "Reject" buttons with a note field for rejections. The buttons are conditionally displayed based on the user's role and the project's status.
- The `ProjectController` is updated to handle the new status workflow and rejection notes.
- The `Project` model is updated to reflect the new statuses.
- Database migrations are added to update the schema and migrate existing data.