### PR TITLE
feat: Allow admin to update project supervisors

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -124,8 +124,9 @@ class ProjectController extends Controller
 
     public function show(Project $project)
     {
-
-        return view('projects.show', compact('project',));
+        $supervisors = User::where('role', 'supervisor')->get();
+        $cosupervisors = User::where('role', 'co-supervisor')->get();
+        return view('projects.show', compact('project', 'supervisors', 'cosupervisors'));
     }
 
     public function edit(Project $project)
@@ -269,5 +270,21 @@ class ProjectController extends Controller
         ]);
 
         return back()->with('success', 'Supervisor assigned successfully.');
+    }
+
+    public function updateSupervisors(Request $request, Project $project)
+    {
+        $this->authorize('update', $project);
+        $request->validate([
+            'supervisor_id' => ['required', 'exists:users,id'],
+            'cosupervisor_id' => ['nullable', 'exists:users,id'],
+        ]);
+
+        $project->update([
+            'supervisor_id' => $request->supervisor_id,
+            'cosupervisor_id' => $request->cosupervisor_id,
+        ]);
+
+        return back()->with('success', 'Supervisors updated successfully.');
     }
 }

--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ProjectPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can update the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Project  $project
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function update(User $user, Project $project)
+    {
+        return $user->role === 'admin';
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,9 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use App\Models\Project;
+use App\Policies\ProjectPolicy;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Pagination\Paginator;
 
 class AppServiceProvider extends ServiceProvider
@@ -22,5 +25,6 @@ class AppServiceProvider extends ServiceProvider
     {
             Paginator::defaultView('vendor.pagination.tailwind');
 
+            Gate::policy(Project::class, ProjectPolicy::class);
     }
 }

--- a/resources/views/profile/partials/delete-user-form.blade.php
+++ b/resources/views/profile/partials/delete-user-form.blade.php
@@ -1,10 +1,10 @@
 <section class="space-y-6">
     <header>
-        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+        <h2 class="text-lg font-medium text-gray-900">
             {{ __('Delete Account') }}
         </h2>
 
-        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+        <p class="mt-1 text-sm text-gray-600">
             {{ __('Once your account is deleted, all of its resources and data will be permanently deleted. Before deleting your account, please download any data or information that you wish to retain.') }}
         </p>
     </header>
@@ -19,11 +19,11 @@
             @csrf
             @method('delete')
 
-            <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+            <h2 class="text-lg font-medium text-gray-900">
                 {{ __('Are you sure you want to delete your account?') }}
             </h2>
 
-            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            <p class="mt-1 text-sm text-gray-600">
                 {{ __('Once your account is deleted, all of its resources and data will be permanently deleted. Please enter your password to confirm you would like to permanently delete your account.') }}
             </p>
 

--- a/resources/views/profile/partials/update-password-form.blade.php
+++ b/resources/views/profile/partials/update-password-form.blade.php
@@ -1,10 +1,10 @@
 <section>
     <header>
-        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+        <h2 class="text-lg font-medium text-gray-900">
             {{ __('Update Password') }}
         </h2>
 
-        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+        <p class="mt-1 text-sm text-gray-600">
             {{ __('Ensure your account is using a long, random password to stay secure.') }}
         </p>
     </header>
@@ -39,7 +39,7 @@
 
             @if (session('status') === 'password-updated')
             <p x-data="{ show: true }" x-show="show" x-transition x-init="setTimeout(() => show = false, 2000)"
-                class="text-sm text-gray-600 dark:text-gray-400">{{ __('Saved.') }}</p>
+                class="text-sm text-gray-600">{{ __('Saved.') }}</p>
             @endif
         </div>
     </form>

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -1,10 +1,10 @@
 <section>
     <header>
-        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+        <h2 class="text-lg font-medium text-gray-900">
             {{ __('Profile Information') }}
         </h2>
 
-        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+        <p class="mt-1 text-sm text-gray-600">
             {{ __("Update your account's profile information and email address.") }}
         </p>
     </header>
@@ -32,17 +32,17 @@
 
             @if ($user instanceof \Illuminate\Contracts\Auth\MustVerifyEmail && ! $user->hasVerifiedEmail())
             <div>
-                <p class="text-sm mt-2 text-gray-800 dark:text-gray-200">
+                <p class="text-sm mt-2 text-gray-800">
                     {{ __('Your email address is unverified.') }}
 
                     <button form="send-verification"
-                        class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800">
+                        class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                         {{ __('Click here to re-send the verification email.') }}
                     </button>
                 </p>
 
                 @if (session('status') === 'verification-link-sent')
-                <p class="mt-2 font-medium text-sm text-green-600 dark:text-green-400">
+                <p class="mt-2 font-medium text-sm text-green-600">
                     {{ __('A new verification link has been sent to your email address.') }}
                 </p>
                 @endif
@@ -69,7 +69,7 @@
 
             @if (session('status') === 'profile-updated')
             <p x-data="{ show: true }" x-show="show" x-transition x-init="setTimeout(() => show = false, 2000)"
-                class="text-sm text-gray-600 dark:text-gray-400">{{ __('Saved.') }}</p>
+                class="text-sm text-gray-600">{{ __('Saved.') }}</p>
             @endif
         </div>
     </form>

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -82,6 +82,37 @@
         </div>
     </div>
 
+    @if(auth()->user()->role == 'admin')
+    <div class="mt-8 pt-4 border-t border-gray-200">
+        <h3 class="text-xl font-semibold text-gray-700 mb-4">Update Supervisors</h3>
+        <form action="{{ route('projects.updateSupervisors', $project) }}" method="POST">
+            @csrf
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                    <label for="supervisor_id" class="text-gray-700 text-sm font-semibold mb-1">Supervisor</label>
+                    <select name="supervisor_id" id="supervisor_id" class="w-full p-2 border rounded-md">
+                        @foreach($supervisors as $supervisor)
+                        <option value="{{ $supervisor->id }}" @if($project->supervisor_id == $supervisor->id) selected @endif>{{ $supervisor->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div>
+                    <label for="cosupervisor_id" class="text-gray-700 text-sm font-semibold mb-1">Co-Supervisor</label>
+                    <select name="cosupervisor_id" id="cosupervisor_id" class="w-full p-2 border rounded-md">
+                        <option value="">Select Co-Supervisor</option>
+                        @foreach($cosupervisors as $cosupervisor)
+                        <option value="{{ $cosupervisor->id }}" @if($project->cosupervisor_id == $cosupervisor->id) selected @endif>{{ $cosupervisor->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+            </div>
+            <div class="flex justify-end mt-4">
+                <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition duration-200">Update Supervisors</button>
+            </div>
+        </form>
+    </div>
+    @endif
+
     {{-- Group Members Section --}}
     <div class="mt-8 pt-4 border-t border-gray-200">
         <h3 class="text-xl font-semibold text-gray-700 mb-4">Group Members</h3>
@@ -160,11 +191,11 @@
 <div class="bg-white p-8 rounded-xl shadow-lg w-full max-w-4xl mx-auto my-8 z-10">
     <section class="space-y-6">
         <header>
-            <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+            <h2 class="text-lg font-medium text-gray-900">
                 {{ __('Reject Project') }}
             </h2>
 
-            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            <p class="mt-1 text-sm text-gray-600">
                 {{ __('Once a project is rejected, this action cannot be undone. Please provide a reason for
                 rejection.') }}
             </p>
@@ -177,11 +208,11 @@
             <form method="post" action="{{ route('projects.reject', $project) }}" class="p-6">
                 @csrf
 
-                <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+                <h2 class="text-lg font-medium text-gray-900">
                     {{ __('Are you sure you want to reject this project?') }}
                 </h2>
 
-                <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                <p class="mt-1 text-sm text-gray-600">
                     {{ __('Please enter a reason for rejecting this project. This reason will be visible to the
                     student.') }}
                 </p>
@@ -211,3 +242,42 @@
 @endif
 
 @endsection
+
+@push('scripts')
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const supervisorSelect = document.getElementById('supervisor_id');
+        const coSupervisorSelect = document.getElementById('cosupervisor_id');
+        const userRole = "{{ auth()->user()->role }}";
+
+        function fetchCoSupervisors(supervisorId) {
+            if (supervisorId) {
+                fetch(`/supervisors/${supervisorId}/co-supervisors`)
+                    .then(response => response.json())
+                    .then(data => {
+                        coSupervisorSelect.innerHTML = '<option value="">Select Co-Supervisor</option>';
+                        data.forEach(coSupervisor => {
+                            const option = document.createElement('option');
+                            option.value = coSupervisor.id;
+                            option.textContent = coSupervisor.name;
+                            coSupervisorSelect.appendChild(option);
+                        });
+                    });
+            } else {
+                coSupervisorSelect.innerHTML = '<option value="">Select Co-Supervisor</option>';
+            }
+        }
+
+        if (userRole !== 'admin') {
+            supervisorSelect.addEventListener('change', function () {
+                fetchCoSupervisors(this.value);
+            });
+
+            // Initial fetch
+            if (supervisorSelect.value) {
+                fetchCoSupervisors(supervisorSelect.value);
+            }
+        }
+    });
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,8 +43,9 @@ Route::middleware(['auth'])->group(function () {
         Route::resource('departments', DepartmentController::class);
         Route::resource('r_cells', RCellController::class);
         Route::post('/projects/{project}/assign-supervisor', [ProjectController::class, 'assignSupervisor'])->name('projects.assignSupervisor');
+        Route::post('/projects/{project}/update-supervisors', [ProjectController::class, 'updateSupervisors'])->name('projects.updateSupervisors');
     });
-    Route::get('/supervisors/{supervisor}/co-supervisors', [UserController::class, 'getCoSupervisors'])->name('supervisors.co-supervisors');
+    Route::get('/supervisors/{supervisor}/co-supervisors', [UserController::class, 'getCoSupervisors'])->name('supervisors.co-supervisors')->middleware('auth');
 });
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
This commit introduces the following changes:

-   Adds the ability for admin users to update the supervisor and co-supervisor of a project from the project's show page.
-   Adds a new route and controller method to handle the update.
-   Adds a form to the project show page for admins to update the supervisors.
-   Adds JavaScript to dynamically populate the co-supervisor dropdown based on the selected supervisor.
-   Adds a project policy to authorize the update action.
-   Removes the `dark` class from the entire project.