### PR TITLE
feat: Add CRUD operations for Company

### DIFF
--- a/app/Http/Controllers/CompanyController.php
+++ b/app/Http/Controllers/CompanyController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Company;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rule;
+
+class CompanyController extends Controller
+{
+
+      public function index(Request $request)
+    {
+        $companiesQuery = Company::query();
+
+        if ($request->has('name') && $request->input('name') !== null) {
+            $companiesQuery->where('name', 'like', '%' . $request->input('name') . '%');
+        }
+
+        $companies = $companiesQuery->paginate(10)->withQueryString();
+        return view('companies.index', compact('companies'));
+    }
+
+    public function create()
+    {
+        return view('companies.create');
+    }
+
+    public function store(Request $request)
+    {
+       $validate = $request->validate([
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'quantity' => 'required|integer',
+        ]);
+
+        Company::create($validate);
+
+
+        return redirect()->route('companies.index')->with('success', 'Company created successfully.');
+    }
+
+    public function show(Company $company)
+    {
+        return view('companies.show', compact('company'));
+    }
+
+    public function edit(Company $company)
+    {
+        return view('companies.edit', compact('company'));
+    }
+
+    public function update(Request $request, Company $company)
+    {
+       $validate = $request->validate([
+            'description' => 'nullable|string',
+            'name' => 'required|string|max:255',
+            'quantity' => 'required|integer',
+        ]);
+
+        $company->update($validate);
+
+        return redirect()->route('companies.index')->with('success', 'Company updated successfully.');
+    }
+
+    public function destroy(Company $company)
+    {
+        $company->delete();
+        return redirect()->route('companies.index')->with('success', 'Company deleted successfully.');
+    }
+}

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Company extends Model
+{
+    protected $fillable = [
+        'name', 'description', 'quantity',
+    ];
+}

--- a/database/migrations/2025_08_18_214630_create_companies_table.php
+++ b/database/migrations/2025_08_18_214630_create_companies_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('companies', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->integer('quantity');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('companies');
+    }
+};

--- a/resources/views/companies/create.blade.php
+++ b/resources/views/companies/create.blade.php
@@ -1,0 +1,53 @@
+@extends('layouts.admin')
+@section('title', 'Create Company')
+@section('content')
+<div class="bg-white p-8 rounded-xl shadow-lg w-full max-w-2xl">
+    <h2 class="text-3xl font-bold text-gray-800 mb-6">Create New Company</h2>
+    <form action="{{ route('companies.store') }}" method="POST">
+        @csrf
+        <!-- Name Field -->
+        <div class="mb-4">
+            <label for="name" class="input_label">Name</label>
+            <input type="text" id="name" name="name" placeholder="Enter company's name" value="{{ old('name') }}"
+                class="input" required>
+
+            @error('name')
+            <p class="validate_error">{{ $message }}</p>
+            @enderror
+
+        </div>
+
+        <!-- description Field -->
+        <div class="mb-4">
+            <label for="description" class="input_label">Description</label>
+            <textarea id="description" name="description" placeholder="Enter description" class="input"
+                >{{ old('description') }}</textarea>
+
+            @error('description')
+            <p class="validate_error">{{ $message }}</p>
+            @enderror
+
+        </div>
+
+        <!-- Quantity Field -->
+        <div class="mb-4">
+            <label for="quantity" class="input_label">Quantity</label>
+            <input type="number" id="quantity" name="quantity" placeholder="Enter quantity" value="{{ old('quantity') }}"
+                class="input" required>
+
+            @error('quantity')
+            <p class="validate_error">{{ $message }}</p>
+            @enderror
+
+        </div>
+
+        <!-- Submit Button -->
+        <div class="flex items-center justify-center">
+            <button type="submit"
+                class="bg-brand-600 hover:bg-brand-700 text-white font-bold py-3 px-6 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-opacity-50 transition duration-200 w-full">
+                Create Company
+            </button>
+        </div>
+    </form>
+</div>
+@endsection

--- a/resources/views/companies/edit.blade.php
+++ b/resources/views/companies/edit.blade.php
@@ -1,0 +1,53 @@
+@extends('layouts.admin')
+@section('title', 'Edit Company')
+@section('content')
+<div class="bg-white p-8 rounded-xl shadow-lg w-full max-w-2xl">
+    <h2 class="text-3xl font-bold text-gray-800 mb-6">Edit Company</h2>
+
+    <form action="{{ route('companies.update', $company) }}" method="POST">
+        @csrf
+        @method('PUT')
+
+        <!-- Name Field -->
+        <div class="mb-4">
+            <label for="name" class="input_label">Name</label>
+            <input type="text" id="name" name="name" placeholder="Enter company's name" class="input"
+                value="{{ old('name', $company->name) }}" required>
+            @error('name')
+            <p class="validate_error">{{ $message }}</p>
+            @enderror
+        </div>
+
+        <!-- description Field -->
+        <div class="mb-4">
+            <label for="description" class="input_label">Description</label>
+            <textarea id="description" name="description" placeholder="Enter description" class="input"
+                >{{ old('description', $company->description) }}</textarea>
+
+            @error('description')
+            <p class="validate_error">{{ $message }}</p>
+            @enderror
+
+        </div>
+
+        <!-- Quantity Field -->
+        <div class="mb-4">
+            <label for="quantity" class="input_label">Quantity</label>
+            <input type="number" id="quantity" name="quantity" placeholder="Enter quantity" class="input"
+                value="{{ old('quantity', $company->quantity) }}" required>
+            @error('quantity')
+            <p class="validate_error">{{ $message }}</p>
+            @enderror
+        </div>
+
+
+        <!-- Submit Button -->
+        <div class="flex items-center justify-center">
+            <button type="submit"
+                class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50 transition duration-200 w-full">
+                Update Company
+            </button>
+        </div>
+    </form>
+</div>
+@endsection

--- a/resources/views/companies/index.blade.php
+++ b/resources/views/companies/index.blade.php
@@ -1,0 +1,146 @@
+@extends('layouts.admin')
+@section('title', 'Companies')
+@section('content')
+<div
+    class=" rounded-2xl border border-gray-200 bg-white px-4 pb-3 pt-4 dark:border-gray-800 dark:bg-white/[0.03] sm:px-6 shadow-lg">
+    <div class="flex flex-col gap-2 mb-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+            <h3 class="text-lg font-semibold text-gray-800 dark:text-white/90">
+                Company List
+            </h3>
+        </div>
+
+        <div class="flex items-center gap-3">
+
+
+            <a href="{{ route('companies.create') }}"
+                class="bg-brand-600 text-white hover:bg-brand-700 transition-all px-5 py-2 rounded font-medium text-sm">Add
+                <i class="fa fa-plus"></i></a>
+
+
+        </div>
+    </div>
+
+    <div class="w-full overflow-x-auto">
+        <table class="min-w-full mb-4">
+            <!-- table header start -->
+            <thead>
+                <tr class="border-gray-100 border-y dark:border-gray-800">
+                    <th class="py-3 text-left">
+                        <div class="flex items-center">
+                            <p class="font-medium text-gray-500 text-theme-xs dark:text-gray-400">
+                                Name
+                            </p>
+                        </div>
+                    </th>
+                    <th class="py-3  text-left">
+                        <div class="flex items-center">
+                            <p class="font-medium text-gray-500 text-theme-xs dark:text-gray-400">
+                                Description
+                            </p>
+                        </div>
+                    </th>
+                    <th class="py-3  text-left">
+                        <div class="flex items-center">
+                            <p class="font-medium text-gray-500 text-theme-xs dark:text-gray-400">
+                                Quantity
+                            </p>
+                        </div>
+                    </th>
+
+                    <th class="py-3  w-5">
+                        <div class="flex items-center ">
+                            <p class="font-medium text-gray-500 text-theme-xs dark:text-gray-400">
+                                Action
+                            </p>
+                        </div>
+                    </th>
+                </tr>
+            </thead>
+            <!-- table header end -->
+
+            <tbody class="divide-y divide-gray-300 dark:divide-gray-800">
+                @foreach ($companies as $item)
+                <tr class="hover:bg-gray-50">
+                    <td class="py-3">
+                        <div class="flex items-center">
+                            <div class="flex items-center gap-3">
+
+                                <div>
+                                    <p class="font-medium text-gray-800 text-theme-sm dark:text-white/90">
+                                        {{ $item->name }} </p>
+
+                                </div>
+                            </div>
+                        </div>
+                    </td>
+                    <td class="py-3">
+                        <div class="flex items-center">
+                            <div class="flex items-center gap-3">
+
+                                <div>
+                                    <p class=" text-gray-500 text-theme-sm dark:text-white/90">
+                                        {{ $item->description ?? "N/A"}} </p>
+
+                                </div>
+                            </div>
+                        </div>
+                    </td>
+                    <td class="py-3">
+                        <div class="flex items-center">
+                            <div class="flex items-center gap-3">
+
+                                <div>
+                                    <p class=" text-gray-500 text-theme-sm dark:text-white/90">
+                                        {{ $item->quantity }} </p>
+
+                                </div>
+                            </div>
+                        </div>
+                    </td>
+
+                    <td class="py-3 px-4 text-right">
+                        <div class="relative inline-block text-left">
+                            <button type="button"
+                                class="inline-flex justify-center w-full rounded-md border border-gray-300 shadow-sm px-2 py-1 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-white/[0.03]"
+                                id="options-menu-{{ $item->id }}" aria-haspopup="true" aria-expanded="true">
+                                <i class="fa-solid fa-ellipsis-vertical"></i>
+                            </button>
+
+                            <div class="origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none z-10 hidden dark:bg-gray-700"
+                                role="menu" aria-orientation="vertical" aria-labelledby="options-menu-{{ $item->id }}">
+                                <div class="py-1" role="none">
+
+
+                                    <a href="{{route('companies.edit', $item->id)}}"
+                                        class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-gray-600"
+                                        role="menuitem">Edit</a>
+
+
+                                    <form method="POST" action="{{route('companies.destroy', $item->id)}}">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit"
+                                            class="block w-full text-left px-4 py-2 text-sm text-red-700 hover:bg-gray-100 hover:text-red-900 dark:text-red-300 dark:hover:bg-gray-600"
+                                            role="menuitem">Delete</button>
+                                    </form>
+
+                                </div>
+                            </div>
+                        </div>
+                    </td>
+
+                </tr>
+                @endforeach
+
+                <!-- table body end -->
+            </tbody>
+        </table>
+
+
+        {{ $companies->links() }}
+    </div>
+</div>
+
+
+@endsection

--- a/resources/views/layouts/partials/sidebar.blade.php
+++ b/resources/views/layouts/partials/sidebar.blade.php
@@ -55,6 +55,20 @@
                         </a>
                     </li>
                     @endif
+                    @if (auth()->user()->role == 'admin')
+                    <li>
+                        <a href="/companies" @click="selected = (selected === 'Company' ? '':'Company')"
+                            class="menu-item group" :class="(selected === 'Company') || {{ request()->is('companies') ? 'true' : 'false' }} ?
+                                    'menu-item-active' : 'menu-item-inactive'">
+                            <i :class="((selected === 'Company') || {{ request()->is('companies') ? 'true' : 'false' }}) ?
+                                'menu-item-icon-active' : 'menu-item-icon-inactive'" class="fa-solid fa-building"></i>
+
+                            <span class="menu-item-text" :class="sidebarToggle ? 'lg:hidden' : ''">
+                                Company
+                            </span>
+                        </a>
+                    </li>
+                    @endif
 
                     @if (auth()->user()->role == 'admin')
                     <li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\AdminController;
 use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\CompanyController;
 use App\Http\Controllers\DepartmentController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ProjectController;
@@ -41,6 +42,7 @@ Route::middleware(['auth'])->group(function () {
     Route::middleware(['role:admin'])->group(function () {
         Route::resource('users', UserController::class);
         Route::resource('departments', DepartmentController::class);
+        Route::resource('companies', CompanyController::class);
         Route::resource('r_cells', RCellController::class);
         Route::post('/projects/{project}/assign-supervisor', [ProjectController::class, 'assignSupervisor'])->name('projects.assignSupervisor');
         Route::post('/projects/{project}/update-supervisors', [ProjectController::class, 'updateSupervisors'])->name('projects.updateSupervisors');


### PR DESCRIPTION
This commit introduces a new CRUD functionality for a 'company' entity.

The following has been added:
- A `companies` table with `name`, `description`, and `quantity` fields.
- A `Company` model.
- A `CompanyController` to handle the CRUD operations.
- Views for creating, editing, and listing companies.
- A resource route for companies.
- A link to the company index page in the sidebar.